### PR TITLE
chore(version): change version to 0.1.0

### DIFF
--- a/pollination_dragonfly_energy/__init__.py
+++ b/pollination_dragonfly_energy/__init__.py
@@ -9,7 +9,7 @@ __queenbee__ = {
     'sources': [
         'https://github.com/ladybug-tools/dragonfly-energy'
     ],
-    'tag': '0.2.0',  # tag for dragonfly-energy plugin on Pollination
+    'tag': '0.1.0',  # tag for dragonfly-energy plugin on Pollination
     'keywords': ['ladybug-tools', 'dragonfly', 'energyplus', 'openstudio', 'energy'],
     'maintainers': [
         {'name': 'chris', 'email': 'chris@ladybug.tools'}


### PR DESCRIPTION
Since this is the first version of dragonfly-energy I changed the version to 0.1.0.

It will also help to explain how the versioning work in Queenbee recipes.